### PR TITLE
Feature/enable and disable in parallel

### DIFF
--- a/src/Context.cs
+++ b/src/Context.cs
@@ -20,12 +20,8 @@ namespace AzDoAgentDrainer
         public async Task Drain()
         {
             Console.WriteLine("Draining Agents");
-
-            foreach (var sc in Servers)
-            {
-                await DrainByServer(sc);
-            }
-
+            
+            await Task.WhenAll(Servers.Select(sc => DrainByServer(sc)));
         }
 
         private async Task DrainByServer(ServerContext sc)
@@ -66,11 +62,7 @@ namespace AzDoAgentDrainer
         public async Task Enable()
         {
             Console.WriteLine("Agents to be enabled:");
-            
-            foreach (var sc in Servers)
-            {
-                await EnableByServer(sc);
-            };
+            await Task.WhenAll(Servers.Select(sc => EnableByServer(sc)));
         }
 
         public async Task EnableByServer(ServerContext sc)


### PR DESCRIPTION
This PR enables agents to disable/enable in parallel.

Previously the library would iterate over a server, then each pool and then wait 15 seconds. This could cause unnecessary delays. 

It now iterates over each server in "parallel" and then each agent pool in "parallel"

Fixes #2 