### PR TITLE
Extend API to enable originally disabled agents

### DIFF
--- a/src/IAgentOperator.cs
+++ b/src/IAgentOperator.cs
@@ -5,5 +5,6 @@ namespace AzDoAgentDrainer
     public interface IAgentOperator{        
         Task DrainAsync();
         Task EnableAsync();
+        Task EnableAllAsync();
     }
 }


### PR DESCRIPTION
Currently some agents are not enabled when the drainer is originally run. The code would not re-enable them because that could have introduced intentionally disabled agents back into the pool.

This expansion allows ALL agents to be enabled, regardless of initial status.