### PR TITLE
Add AzureVmAgentsService

### DIFF
--- a/AzDoAgentDrainer.sln
+++ b/AzDoAgentDrainer.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureDevopsAgentOperator.CL
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureDevopsAgentOperator", "src\AzureDevopsAgentOperator\AzureDevopsAgentOperator.csproj", "{089C70FE-1F52-4501-A29F-75FE82BA89D0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureVmAgentsService", "src\AzureVmAgentsService\AzureVmAgentsService.csproj", "{7B97B131-8C97-4345-BC17-71C8DB14567D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,18 @@ Global
 		{089C70FE-1F52-4501-A29F-75FE82BA89D0}.Release|x64.Build.0 = Release|Any CPU
 		{089C70FE-1F52-4501-A29F-75FE82BA89D0}.Release|x86.ActiveCfg = Release|Any CPU
 		{089C70FE-1F52-4501-A29F-75FE82BA89D0}.Release|x86.Build.0 = Release|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Debug|x64.Build.0 = Debug|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Debug|x86.Build.0 = Debug|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Release|x64.ActiveCfg = Release|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Release|x64.Build.0 = Release|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Release|x86.ActiveCfg = Release|Any CPU
+		{7B97B131-8C97-4345-BC17-71C8DB14567D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AzureVmAgentsService/AzureVmAgentsService.csproj
+++ b/src/AzureVmAgentsService/AzureVmAgentsService.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.0.0" />
+    <PackageReference Include="refit" Version="5.0.23" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="5.0.23" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AzureDevopsAgentOperator\AzureDevopsAgentOperator.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AzureVmAgentsService/Models/ApproveScheduldedEvents.cs
+++ b/src/AzureVmAgentsService/Models/ApproveScheduldedEvents.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace AzureVmAgentsService.Models
+{
+    public class ApproveScheduldedEvents
+    {
+        public List<ScheduldedEvents> StartRequests { get; set; }
+    }
+
+
+}

--- a/src/AzureVmAgentsService/Models/AzureDevopsConfig.cs
+++ b/src/AzureVmAgentsService/Models/AzureDevopsConfig.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace AzureVmAgentsService.Models
+{
+    public class AzureDevopsConfig
+    {
+        public Uri Uri { get; set; }
+        public string Pat { get; set; }
+        public string ComputerName { get; set; }        
+    }
+}
+
+

--- a/src/AzureVmAgentsService/Models/IInstanceMetadataServiceAPI.cs
+++ b/src/AzureVmAgentsService/Models/IInstanceMetadataServiceAPI.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Refit;
+
+namespace AzureVmAgentsService.Models
+{
+    public interface IInstanceMetadataServiceAPI
+    {
+        [Headers("Metadata: True")]
+        [Get("/metadata/instance/compute/name?api-version=2019-03-11&format=text")]
+        Task<string> GetVMName();
+
+        [Headers("Metadata: True")]
+        [Get("/metadata/scheduledevents?api-version=2019-01-01")]
+        Task<ScheduldedEventsResponse> GetScheduldedEvents();
+
+        [Headers("Metadata: True")]
+        [Post("/metadata/scheduledevents?api-version=2019-01-01")]
+        Task<string> AcknowledgeScheduldedEvent([Body]object s);
+    }
+
+
+}

--- a/src/AzureVmAgentsService/Models/ScheduldedEvents.cs
+++ b/src/AzureVmAgentsService/Models/ScheduldedEvents.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace AzureVmAgentsService.Models
+{
+    public class ScheduldedEvents
+    {
+        public string EventId { get; set; }
+        public string EventType { get; set; }
+        public string ResourceType { get; set; }
+        public List<string> Resources { get; set; }
+        public string EventStatus { get; set; }
+        public DateTime NotBefore { get; set; }
+    }
+}

--- a/src/AzureVmAgentsService/Models/ScheduldedEventsResponse.cs
+++ b/src/AzureVmAgentsService/Models/ScheduldedEventsResponse.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace AzureVmAgentsService.Models
+{
+    public class ScheduldedEventsResponse
+    {
+        public int DocumentIncarnation { get; set; }
+        public List<ScheduldedEvents> Events { get; set; }
+    }
+
+
+}

--- a/src/AzureVmAgentsService/Program.cs
+++ b/src/AzureVmAgentsService/Program.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Refit;
+using Microsoft.Extensions.Configuration;
+using AzureDevopsAgentOperator;
+using AzureVmAgentsService.Models;
+
+namespace AzureVmAgentsService
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)               
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddHostedService<Worker>();
+                    services.AddRefitClient<IInstanceMetadataServiceAPI>()
+                        .ConfigureHttpClient(c =>
+                        {
+                            c.BaseAddress = new Uri("http://169.254.169.254");
+
+                            /* Scheduled Events is enabled for your service the first time you make a request for events.
+                               You should expect a delayed response in your first call of up to two minutes.
+                               https://docs.microsoft.com/en-gb/azure/virtual-machines/windows/scheduled-events */
+                            c.Timeout = TimeSpan.FromSeconds(120);
+                        })
+                        .AddTransientHttpErrorPolicy(p => p.RetryAsync(3));
+
+                    services.AddSingleton<IAgentOperator, AgentOperator>(sp =>
+                    {                        
+                        var config = sp.GetService<IConfiguration>().GetSection("drainer").Get<AzureDevopsConfig>();
+                        var loggerFactory = sp.GetService<ILoggerFactory>();
+                        var hostEnv = sp.GetService<IHostEnvironment>();
+
+                        var computerName = hostEnv.IsProduction() ? Environment.MachineName : config.ComputerName;
+
+                        if (string.IsNullOrEmpty(computerName))
+                            throw new Exception("A drainer:computername has not been set in configuration");
+
+                        return new AgentOperatorBuilder()
+                          .AddLogger(loggerFactory.CreateLogger("AgentOperator"))
+                          .AddInstance(config.Uri, config.Pat)
+                          .SelectAgents(x =>
+                          {
+                              return x.Where(agent => agent.ComputerName.ToUpper() == computerName);
+                          })
+                          .Build().Result;
+                    });
+                });
+    }
+}
+
+

--- a/src/AzureVmAgentsService/Worker.cs
+++ b/src/AzureVmAgentsService/Worker.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AzureDevopsAgentOperator;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using AzureVmAgentsService.Models;
+
+namespace AzureVmAgentsService
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _logger;
+        private readonly IInstanceMetadataServiceAPI _instanceMetadataServiceAPI;
+        private IAgentOperator _agentsContext;
+
+        public Worker(ILogger<Worker> logger, IInstanceMetadataServiceAPI scheduldedEventsAPI, IAgentOperator agentsContext)
+        {
+            _logger = logger;
+            _instanceMetadataServiceAPI = scheduldedEventsAPI;
+            _agentsContext = agentsContext;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Query the Instance Metadata Service for the VM name. This may be different to the computer name. The VMName is used in the schdeduled events to specify the machines that may be affcted.
+            var _computerName = await _instanceMetadataServiceAPI.GetVMName();
+            _logger.LogInformation("VMName ${wmvname}", _computerName);
+
+            // Discover the initial documentIncarnation number for comparsion later on to see if it has changed
+            var events = await _instanceMetadataServiceAPI.GetScheduldedEvents();
+            var _documentIncarnation = events.DocumentIncarnation;
+
+            // Ensure all agents are enabled on this server to begin with
+            await _agentsContext.EnableAllAsync();            
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var scheduldedEventsReponse = await _instanceMetadataServiceAPI.GetScheduldedEvents();
+
+                if (_documentIncarnation != scheduldedEventsReponse.DocumentIncarnation) // Then a new event has occured and we need to check if something about to happen to this VM.
+                {
+                    _logger.LogInformation("DocumentIncarnation changed from {previous} to {current}", _documentIncarnation, scheduldedEventsReponse.DocumentIncarnation);
+                    _documentIncarnation = scheduldedEventsReponse.DocumentIncarnation; // Update the DocumentIncarnation so we don't try to handle the SchdeduldedEvent again.
+
+                    var relevantEvents = scheduldedEventsReponse.Events.Where(x => x.Resources.Exists(x => x.ToUpper() == _computerName.ToUpper()));
+                    _logger.LogInformation("Found {eventcount}", relevantEvents.Count());
+                    relevantEvents.ToList().ForEach(x => _logger.LogInformation($"EventId: {x.EventId}, EventType: {x.EventType}, NotBefore: {x.NotBefore}"));
+
+                    if (relevantEvents.Any(x => string.Equals(x.EventType, "Reboot", System.StringComparison.OrdinalIgnoreCase) || string.Equals(x.EventType, "Redeploy", System.StringComparison.OrdinalIgnoreCase)))
+                    {
+                        await _agentsContext.DrainAsync();
+                    }
+                    else if (relevantEvents.Any(x => string.Equals(x.EventType, "Terminate", System.StringComparison.OrdinalIgnoreCase)))
+                    {
+                        // Remove the agent
+                    }
+
+                    _logger.LogInformation("Acknowlding {events}", relevantEvents);
+                    relevantEvents.ToList().ForEach(x => _logger.LogInformation($"Acknowlding {x.EventId}"));
+                    _ = await _instanceMetadataServiceAPI.AcknowledgeScheduldedEvent(new { StartRequests = relevantEvents });
+                }
+            }
+            await Task.Delay(10000, stoppingToken);
+        }
+    }
+}

--- a/src/AzureVmAgentsService/appsettings.Development.json
+++ b/src/AzureVmAgentsService/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/src/AzureVmAgentsService/appsettings.json
+++ b/src/AzureVmAgentsService/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "drainer": {
+    "uri": "",
+    "pat": "",
+    "computerName": ""
+  }
+}
+   


### PR DESCRIPTION
This PR adds the base for the AzureVMAgentService. This is a .Net Core application that subscribes to the Azure IMDS and polls for scheduled events. When a scheduled event occurs, it attempts to drain the server by disabling any Azure DevOps agents running on the server and then approving the scheduled event.