### PR TITLE
Fix string comparison bug 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
      gitHubConnection: UKHO GitHub
      repositoryName: UKHO/AzDoAgentDrainer     
      tagSource: userSpecifiedTag
-     tag: v0.2.2 
+     tag: v0.2.3 
      assets: |
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.zip
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.tar.gz

--- a/src/AzureVmAgentsService/Program.cs
+++ b/src/AzureVmAgentsService/Program.cs
@@ -42,18 +42,21 @@ namespace AzureVmAgentsService
                         var config = sp.GetService<IConfiguration>().GetSection("drainer").Get<AzureDevopsConfig>();
                         var loggerFactory = sp.GetService<ILoggerFactory>();
                         var hostEnv = sp.GetService<IHostEnvironment>();
+                        var logger = loggerFactory.CreateLogger("AgentOperator");
 
-                        var computerName = hostEnv.IsProduction() ? Environment.MachineName : config.ComputerName;
+                        var computerName = hostEnv.IsProduction() ? Environment.MachineName.ToUpper() : config.ComputerName.ToUpper();
 
                         if (string.IsNullOrEmpty(computerName))
                             throw new Exception("A drainer:computername has not been set in configuration");
 
+                        logger.LogInformation("MachineName is {machineName}", computerName);
+
                         return new AgentOperatorBuilder()
-                          .AddLogger(loggerFactory.CreateLogger("AgentOperator"))
+                          .AddLogger(logger)
                           .AddInstance(config.Uri, config.Pat)
                           .SelectAgents(x =>
                           {
-                              return x.Where(agent => agent.ComputerName.ToUpper() == computerName);
+                              return x.Where(agent => agent.ComputerName.ToUpper() == computerName.ToUpper());
                           })
                           .Build().Result;
                     });

--- a/src/AzureVmAgentsService/Worker.cs
+++ b/src/AzureVmAgentsService/Worker.cs
@@ -25,7 +25,7 @@ namespace AzureVmAgentsService
         {
             // Query the Instance Metadata Service for the VM name. This may be different to the computer name. The VMName is used in the schdeduled events to specify the machines that may be affcted.
             var _computerName = await _instanceMetadataServiceAPI.GetVMName();
-            _logger.LogInformation("VMName ${wmvname}", _computerName);
+            _logger.LogInformation("Azure VMName {wmvname}", _computerName);
 
             // Discover the initial documentIncarnation number for comparsion later on to see if it has changed
             var events = await _instanceMetadataServiceAPI.GetScheduldedEvents();


### PR DESCRIPTION
When discovering the agents to disable and enable, the computerName of each agent was uppercased, whereas the computerName of the computer it was being compared to was not uppercased.

This PR fixes that by adding an additional `ToUpper()` when the variable is assigned. It is also `ToUpper()`  "for show" on the comparison itself otherwise it looks like the comparison is incorrect.

The logging is also improved in the configuration section and a log message is tweaked to remove an irrelevant `$`