### PR TITLE
Correct loop pause

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
      gitHubConnection: UKHO GitHub
      repositoryName: UKHO/AzDoAgentDrainer     
      tagSource: userSpecifiedTag
-     tag: v0.2.3 
+     tag: v0.2.4 
      assets: |
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.zip
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.tar.gz

--- a/src/AzureVmAgentsService/Worker.cs
+++ b/src/AzureVmAgentsService/Worker.cs
@@ -36,6 +36,7 @@ namespace AzureVmAgentsService
 
             while (!stoppingToken.IsCancellationRequested)
             {
+                _logger.LogDebug("Checking for ScheduldedEvents");
                 var scheduldedEventsReponse = await _instanceMetadataServiceAPI.GetScheduldedEvents();
 
                 if (_documentIncarnation != scheduldedEventsReponse.DocumentIncarnation) // Then a new event has occured and we need to check if something about to happen to this VM.
@@ -60,8 +61,10 @@ namespace AzureVmAgentsService
                     relevantEvents.ToList().ForEach(x => _logger.LogInformation($"Acknowlding {x.EventId}"));
                     _ = await _instanceMetadataServiceAPI.AcknowledgeScheduldedEvent(new { StartRequests = relevantEvents });
                 }
+                await Task.Delay(10000, stoppingToken);
             }
-            await Task.Delay(10000, stoppingToken);
+            _logger.LogWarning("Exited checking for ScheduldedEvents");
+
         }
     }
 }


### PR DESCRIPTION
The 10 second pause at the end of each check ScheduldedEvents cycle was in the wrong place. Meaning instead the drainer pummelled the ScheduldedEvents endpoint and hit the rate limit . Moving the pause within loop should prevent this.

Additionally added logging that would have been useful for debugging.