### PR TITLE
EnableAllAsync() needs to update the state of agents that can be operated on

### DIFF
--- a/src/AzureDevopsAgentOperator/Agent.cs
+++ b/src/AzureDevopsAgentOperator/Agent.cs
@@ -12,7 +12,7 @@ namespace AzureDevopsAgentOperator
         public string Name { get; }
         public int PoolID { get; }
         public string ProvisioningState { get; }
-        public bool Reenable { get; } = false;
+        public bool AllowOperations { get; private set; } = false;
         public int Status { get; }
         public string OSDescription { get; }
         public IDictionary<string, string> Capabilities { get; }
@@ -23,12 +23,17 @@ namespace AzureDevopsAgentOperator
             this.CreatedOn = taskAgent.CreatedOn;
             this.Id = taskAgent.Id;
             this.Name = taskAgent.Name;
-            this.Reenable = taskAgent.Enabled ?? false;
+            this.AllowOperations = taskAgent.Enabled ?? false;
             this.PoolID = PoolId;
             this.ProvisioningState = taskAgent.ProvisioningState;
             this.Status = (int)taskAgent.Status;
             this.OSDescription = taskAgent.OSDescription;
             this.Capabilities = taskAgent.SystemCapabilities;
+        }
+
+        public void EnableAllowOperations()
+        {
+            this.AllowOperations = true;
         }
     }    
 }


### PR DESCRIPTION
`EnableAllAsync()` will enable agents which originally may have been filtered as their state when the drainer first run was disabled.

When subsequent runs of of `DisableAsync()`, these agents will be missed and not drained correctly. 

This PR adds logic to `EnableAllAsync()` to update the background state to allow these agents to be drained.

Reenable has also be renamed AllowOperations to make it clear that the purpose of this flag is to help the operator decide which agents it can operate on(e.g. enable/disable)