### PR TITLE
Only acknowledge relevant events

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
      gitHubConnection: UKHO GitHub
      repositoryName: UKHO/AzDoAgentDrainer     
      tagSource: userSpecifiedTag
-     tag: v0.2.5 
+     tag: v0.2.6 
      assets: |
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.zip
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.tar.gz


### PR DESCRIPTION
The scheduled events API on VMs is limited to only events that affecting that particular VM. 

This is untrue for VMSS where events are sent to the whole VMSS set, including those not relevant to the VM. This led to a bug where a drainer on a VM acknowledged an event not relevant to them, another drainer then tried to acknowledge the same event causing an error to be thrown.