### PR TITLE
Delete Agent when Terminate event is received

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
      gitHubConnection: UKHO GitHub
      repositoryName: UKHO/AzDoAgentDrainer     
      tagSource: userSpecifiedTag
-     tag: v0.2.6 
+     tag: v0.3.0 
      assets: |
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.zip
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.tar.gz

--- a/src/AzureDevopsAgentOperator/IAgentOperator.cs
+++ b/src/AzureDevopsAgentOperator/IAgentOperator.cs
@@ -6,5 +6,6 @@ namespace AzureDevopsAgentOperator
         Task DrainAsync();
         Task EnableAsync();
         Task EnableAllAsync();
+        Task DeleteAllAsync();
     }
 }

--- a/src/AzureVmAgentsService/Worker.cs
+++ b/src/AzureVmAgentsService/Worker.cs
@@ -60,8 +60,8 @@ namespace AzureVmAgentsService
                             // Remove the agent
                         }
 
-                        _logger.LogInformation("Acknowlding {events}", relevantEvents);
-                        relevantEvents.ToList().ForEach(x => _logger.LogInformation($"Acknowlding {x.EventId}"));
+                        _logger.LogInformation("Acknowledging {events}", relevantEvents);
+                        relevantEvents.ToList().ForEach(x => _logger.LogInformation($"Acknowledging {x.EventId}"));
                         try
                         {
                             _ = await _instanceMetadataServiceAPI.AcknowledgeScheduldedEvent(new { StartRequests = relevantEvents });

--- a/src/AzureVmAgentsService/Worker.cs
+++ b/src/AzureVmAgentsService/Worker.cs
@@ -57,7 +57,9 @@ namespace AzureVmAgentsService
                         }
                         else if (relevantEvents.Any(x => string.Equals(x.EventType, "Terminate", System.StringComparison.OrdinalIgnoreCase)))
                         {
-                            // Remove the agent
+                            // Ensure all the agents are disabled before deleting them
+                            await _agentsContext.DrainAsync();
+                            await _agentsContext.DeleteAllAsync();                            
                         }
 
                         _logger.LogInformation("Acknowledging {events}", relevantEvents);


### PR DESCRIPTION
When running in a VMSS it is possible to receive a `Terminate` [event](https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-terminate-notification). This PR adds logic to handle this event.

When the `Terminate` event is received, all agents running on the VM are disabled and drained. The agents are then deleted from their registered pool on Azure DevOps. The drainer does not delete the agent off the VM itself as it assumes the event will cause the underlying server itself to be removed so is redundant.

The agents are deleted from their registered pool by using the [delete](https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/agents/delete?view=azure-devops-rest-5.1) verb.
 
Fixes #22 