### PR TITLE
Correct retry logic

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
      gitHubConnection: UKHO GitHub
      repositoryName: UKHO/AzDoAgentDrainer     
      tagSource: userSpecifiedTag
-     tag: v0.3.1 
+     tag: v0.3.2 
      assets: |
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.zip
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.tar.gz

--- a/src/AzureVmAgentsService/AzureVmAgentsService.csproj
+++ b/src/AzureVmAgentsService/AzureVmAgentsService.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.1" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="refit" Version="5.0.23" />
     <PackageReference Include="Refit.HttpClientFactory" Version="5.0.23" />
   </ItemGroup>

--- a/src/AzureVmAgentsService/Program.cs
+++ b/src/AzureVmAgentsService/Program.cs
@@ -8,11 +8,14 @@ using Refit;
 using Microsoft.Extensions.Configuration;
 using AzureDevopsAgentOperator;
 using AzureVmAgentsService.Models;
+using Polly.Extensions.Http;
 
 namespace AzureVmAgentsService
 {
     public class Program
     {
+        static Random jitterer = new Random();
+
         public static void Main(string[] args)
         {
             CreateHostBuilder(args).Build().Run();
@@ -35,8 +38,18 @@ namespace AzureVmAgentsService
                                https://docs.microsoft.com/en-gb/azure/virtual-machines/windows/scheduled-events */
                             c.Timeout = TimeSpan.FromSeconds(120);
                         })
-                        .AddTransientHttpErrorPolicy(p => p.RetryAsync(3));
-
+                        .AddPolicyHandler(p => HttpPolicyExtensions
+                            .HandleTransientHttpError()
+                            .OrResult(r => (int)r.StatusCode == 410) // Retry after some time for a max of 70 seconds 
+                            .OrResult(r => (int)r.StatusCode == 429) // The API currently supports a maximum of 5 queries per second
+                            .WaitAndRetryAsync(new[]
+                            {
+                                TimeSpan.FromSeconds(jitterer.Next(3, 10)),
+                                TimeSpan.FromSeconds(jitterer.Next(12, 22)),
+                                TimeSpan.FromSeconds(jitterer.Next(21, 31)),
+                                TimeSpan.FromSeconds(jitterer.Next(36, 50)),
+                                TimeSpan.FromSeconds(jitterer.Next(51, 60))
+                            }));
                     services.AddSingleton<IAgentOperator, AgentOperator>(sp =>
                     {                        
                         var config = sp.GetService<IConfiguration>().GetSection("drainer").Get<AzureDevopsConfig>();


### PR DESCRIPTION
The configured retry does not work under several circumstances, on particular when being rated limited.

`HandleTransientHttpError()` only covers Network failures (System.Net.Http.HttpRequestException), HTTP 5XX status codes (server errors) and HTTP 408 status code (request timeout).

This causes some important use cases to not be covered of where the IMDS will applies rate limiting for exceeding 5 requests pers seconds and return either 410 or 429 -[Docs](https://docs.microsoft.com/bs-latn-ba/azure/virtual-machines/windows/instance-metadata-service#error)

This PR adds support for retrying the 410 and 429 status codes. It also retries with much larger gaps between attempts as the IMDS appears to have a potentially long cooldown period. Additionally adds a very basic jitterer to spread out retried requests to prevent retriggering the rate limiting.

