### PR TITLE
Stop drainer after disabling

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
      gitHubConnection: UKHO GitHub
      repositoryName: UKHO/AzDoAgentDrainer     
      tagSource: userSpecifiedTag
-     tag: v0.3.2 
+     tag: v0.3.3 
      assets: |
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.zip
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.tar.gz


### PR DESCRIPTION
Once the drainer has disabled the agents and acknowledged the event, it continues looping. This causes the event to be acknowledged multiple times which can lead to problems.

This PR logic to stop the drainer once it has acknowledged the event to prevent this happening.