### PR TITLE
NotBefore should be a string

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
      gitHubConnection: UKHO GitHub
      repositoryName: UKHO/AzDoAgentDrainer     
      tagSource: userSpecifiedTag
-     tag: v0.3.6
+     tag: v0.3.7
      assets: |
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.zip
        $(Build.ArtifactStagingDirectory)/azurevmagentservice.tar.gz

--- a/src/AzureVmAgentsService/Models/ScheduldedEvents.cs
+++ b/src/AzureVmAgentsService/Models/ScheduldedEvents.cs
@@ -6,10 +6,10 @@ namespace AzureVmAgentsService.Models
     public class ScheduldedEvents
     {
         public string EventId { get; set; }
+        public string EventStatus { get; set; }
         public string EventType { get; set; }
         public string ResourceType { get; set; }
-        public List<string> Resources { get; set; }
-        public string EventStatus { get; set; }
-        public DateTime NotBefore { get; set; }
+        public List<string> Resources { get; set; }       
+        public string NotBefore { get; set; }
     }
 }


### PR DESCRIPTION
The IMDS returns `"NotBefore"` in the form `"Tue, 10 Mar 2020 14:37:32 GMT"` or `""` for when it has the event has been scheduled.

I think one of these is not being deserialized correctly, I suspect the latter as the drainer works at least once so it can probably deserialize `"Tue, 10 Mar 2020 14:37:32 GMT"` but struggles with the empty string. 

This PR converts NotBefore from a datetime to a string as we don't use NotBefore for anything but logging.